### PR TITLE
Add Flutter themed skeleton

### DIFF
--- a/docs/migrating_to_flutter.md
+++ b/docs/migrating_to_flutter.md
@@ -1,0 +1,44 @@
+# Migración a Flutter
+
+Este documento resume los pasos para reconstruir la aplicación **Fintouch**, creada originalmente con Next.js y React, utilizando Flutter. Siga esta guía para mantener las funcionalidades existentes al pasar a la nueva plataforma.
+
+## 1. Crear un nuevo proyecto
+
+```bash
+flutter create fintouch_flutter
+cd fintouch_flutter
+```
+
+## 2. Configurar Firebase
+
+- Agregue Firebase para Android e iOS siguiendo la [documentación de FlutterFire](https://firebase.flutter.dev/docs/overview).
+- Incluya autenticación y Firestore.
+- Copie la configuración que se encuentra en `src/lib/firebase.ts` a los archivos `google-services.json` (Android) y `GoogleService-Info.plist` (iOS).
+
+## 3. Modelos y servicios
+
+- Convierta las interfaces de TypeScript definidas en `src/lib/types.ts` a clases de Dart.
+- Implemente servicios para autenticación, lecturas y escrituras en Firestore y manejo de estado.
+
+## 4. Replicar pantallas y funciones
+
+- Cree pantallas para inicio de sesión, onboarding, panel principal, categorías, presupuestos e informes.
+- Utilice `provider` o `riverpod` para la gestión de estado.
+- Reimplemente las funciones de grabación de audio y OCR con `speech_to_text`, `image_picker` y `google_mlkit_ocr` (o paquetes equivalentes).
+
+## 5. Pautas de estilo
+
+Siga las especificaciones de `docs/blueprint.md`:
+
+- **Color primario:** Azul saturado `#4285F4`.
+- **Color de fondo:** Azul grisáceo claro `#E8F0FE`.
+- **Color de acento:** Verde vívido `#34A853`.
+- **Fuentes:** Títulos en "Space Grotesk" y cuerpo en "Inter".
+- Use un diseño adaptativo para soportar dispositivos móviles y web.
+
+## 6. Probar e iterar
+
+- Valide los flujos de autenticación y la sincronización con la base de datos.
+- Asegúrese de que todas las funcionalidades existentes funcionen igual que en la versión React.
+
+Cada componente y página deberá reimplementarse manualmente utilizando widgets de Flutter. Este resumen se basa en la estructura y los lineamientos presentes en este proyecto.

--- a/fintouch_flutter/README.md
+++ b/fintouch_flutter/README.md
@@ -1,0 +1,17 @@
+# Fintouch Flutter
+
+Este directorio contiene una versión inicial de la aplicación Fintouch hecha en Flutter.
+Incluye modelos convertidos desde TypeScript y un punto de entrada básico.
+
+## Uso rápido
+
+```bash
+flutter pub get
+flutter run
+```
+
+El tema de la aplicación se define en `lib/theme.dart` siguiendo la paleta y tipografías descritas en `docs/blueprint.md`.
+Se utiliza `provider` para un estado simple en `lib/providers/app_state.dart`.
+
+Para la configuración de Firebase copie las credenciales de `src/lib/firebase.ts` a los
+archivos `google-services.json` y `GoogleService-Info.plist` de cada plataforma.

--- a/fintouch_flutter/lib/main.dart
+++ b/fintouch_flutter/lib/main.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'providers/app_state.dart';
+import 'theme.dart';
+
+void main() {
+  runApp(const FintouchApp());
+}
+
+class FintouchApp extends StatelessWidget {
+  const FintouchApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => AppState(),
+      child: MaterialApp(
+        title: 'Fintouch',
+        theme: AppTheme.themeData,
+        home: const HomePage(),
+      ),
+    );
+  }
+}
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final state = Provider.of<AppState>(context);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Fintouch')),
+      backgroundColor: AppTheme.backgroundColor,
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => state.setUser('demo'),
+          child: Text(
+            state.userId.isEmpty
+                ? 'Login (mock)'
+                : 'Logged in as ${state.userId}',
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/fintouch_flutter/lib/models.dart
+++ b/fintouch_flutter/lib/models.dart
@@ -1,0 +1,102 @@
+class UserCategory {
+  final String id;
+  final String name;
+  final String icon;
+  final String color;
+  final String type;
+  final bool? isDefault;
+
+  UserCategory({
+    required this.id,
+    required this.name,
+    required this.icon,
+    required this.color,
+    required this.type,
+    this.isDefault,
+  });
+}
+
+class Transaction {
+  final String id;
+  final String date;
+  final String description;
+  final double amount;
+  final String type;
+  final String category;
+  final String recurrence;
+  final String currency;
+
+  Transaction({
+    required this.id,
+    required this.date,
+    required this.description,
+    required this.amount,
+    required this.type,
+    required this.category,
+    required this.recurrence,
+    required this.currency,
+  });
+}
+
+class RecurringTransaction {
+  final String id;
+  final String description;
+  final double amount;
+  final String type;
+  final String category;
+  final String recurrence;
+  final String currency;
+
+  RecurringTransaction({
+    required this.id,
+    required this.description,
+    required this.amount,
+    required this.type,
+    required this.category,
+    required this.recurrence,
+    required this.currency,
+  });
+}
+
+class Budget {
+  final String id;
+  final String category;
+  final double amount;
+  final String period;
+  double? spentAmount;
+  double? remainingAmount;
+  double? progressPercentage;
+
+  Budget({
+    required this.id,
+    required this.category,
+    required this.amount,
+    required this.period,
+    this.spentAmount,
+    this.remainingAmount,
+    this.progressPercentage,
+  });
+}
+
+class CategorizationResult {
+  final String category;
+  final double confidence;
+
+  CategorizationResult({required this.category, required this.confidence});
+}
+
+class ReceiptDetails {
+  final String date;
+  final String merchant;
+  final double amount;
+
+  ReceiptDetails({required this.date, required this.merchant, required this.amount});
+}
+
+class UserProfile {
+  final String name;
+  final String language;
+  final String currency;
+
+  UserProfile({required this.name, required this.language, required this.currency});
+}

--- a/fintouch_flutter/lib/providers/app_state.dart
+++ b/fintouch_flutter/lib/providers/app_state.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/foundation.dart';
+
+class AppState extends ChangeNotifier {
+  String userId = '';
+
+  void setUser(String id) {
+    userId = id;
+    notifyListeners();
+  }
+}

--- a/fintouch_flutter/lib/services/auth_service.dart
+++ b/fintouch_flutter/lib/services/auth_service.dart
@@ -1,0 +1,15 @@
+import 'package:firebase_auth/firebase_auth.dart';
+
+class AuthService {
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+
+  Stream<User?> get userChanges => _auth.userChanges();
+
+  Future<UserCredential> signInAnonymously() {
+    return _auth.signInAnonymously();
+  }
+
+  Future<void> signOut() {
+    return _auth.signOut();
+  }
+}

--- a/fintouch_flutter/lib/theme.dart
+++ b/fintouch_flutter/lib/theme.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class AppTheme {
+  static const Color primaryColor = Color(0xFF4285F4);
+  static const Color accentColor = Color(0xFF34A853);
+  static const Color backgroundColor = Color(0xFFE8F0FE);
+
+  static ThemeData get themeData => ThemeData(
+        primaryColor: primaryColor,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: primaryColor,
+          primary: primaryColor,
+          secondary: accentColor,
+          background: backgroundColor,
+        ),
+        textTheme: TextTheme(
+          headlineMedium: GoogleFonts.spaceGrotesk(),
+          bodyLarge: GoogleFonts.inter(),
+          bodyMedium: GoogleFonts.inter(),
+        ),
+      );
+}

--- a/fintouch_flutter/pubspec.yaml
+++ b/fintouch_flutter/pubspec.yaml
@@ -1,0 +1,20 @@
+name: fintouch_flutter
+publish_to: "none"
+version: 0.1.0
+environment:
+  sdk: '>=3.2.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  firebase_core: ^2.30.0
+  firebase_auth: ^4.17.0
+  cloud_firestore: ^4.15.0
+  provider: ^6.1.1
+  google_fonts: ^6.2.1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- expand Flutter app with provider-based state and theme
- implement colors and fonts from blueprint
- add placeholder home page and auth service

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_685b0d6705a08326b7bd4c50f8f4b0cc