### PR TITLE
Add Dart models and Firebase services

### DIFF
--- a/fintouch_flutter/lib/models.dart
+++ b/fintouch_flutter/lib/models.dart
@@ -1,9 +1,11 @@
+enum TransactionType { income, expense }
+
 class UserCategory {
   final String id;
   final String name;
   final String icon;
   final String color;
-  final String type;
+  final TransactionType type;
   final bool? isDefault;
 
   UserCategory({
@@ -21,7 +23,7 @@ class Transaction {
   final String date;
   final String description;
   final double amount;
-  final String type;
+  final TransactionType type;
   final String category;
   final String recurrence;
   final String currency;
@@ -42,7 +44,7 @@ class RecurringTransaction {
   final String id;
   final String description;
   final double amount;
-  final String type;
+  final TransactionType type;
   final String category;
   final String recurrence;
   final String currency;
@@ -66,6 +68,7 @@ class Budget {
   double? spentAmount;
   double? remainingAmount;
   double? progressPercentage;
+  List<Transaction>? transactions;
 
   Budget({
     required this.id,
@@ -75,6 +78,7 @@ class Budget {
     this.spentAmount,
     this.remainingAmount,
     this.progressPercentage,
+    this.transactions,
   });
 }
 

--- a/fintouch_flutter/lib/services/auth_service.dart
+++ b/fintouch_flutter/lib/services/auth_service.dart
@@ -9,6 +9,14 @@ class AuthService {
     return _auth.signInAnonymously();
   }
 
+  Future<UserCredential> signInWithEmail(String email, String password) {
+    return _auth.signInWithEmailAndPassword(email: email, password: password);
+  }
+
+  Future<UserCredential> registerWithEmail(String email, String password) {
+    return _auth.createUserWithEmailAndPassword(email: email, password: password);
+  }
+
   Future<void> signOut() {
     return _auth.signOut();
   }

--- a/fintouch_flutter/lib/services/firestore_service.dart
+++ b/fintouch_flutter/lib/services/firestore_service.dart
@@ -1,0 +1,67 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../models.dart';
+
+class FirestoreService {
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
+
+  CollectionReference<Map<String, dynamic>> _userCollection(String uid, String path) {
+    return _db.collection('users').doc(uid).collection(path);
+  }
+
+  // User profile
+  Future<void> setUserProfile(String uid, UserProfile profile) {
+    return _db.collection('users').doc(uid).set({
+      'name': profile.name,
+      'language': profile.language,
+      'currency': profile.currency,
+    }, SetOptions(merge: true));
+  }
+
+  Stream<UserProfile?> watchUserProfile(String uid) {
+    return _db.collection('users').doc(uid).snapshots().map((doc) {
+      if (!doc.exists) return null;
+      final data = doc.data()!;
+      return UserProfile(
+        name: data['name'] ?? '',
+        language: data['language'] ?? 'en',
+        currency: data['currency'] ?? 'USD',
+      );
+    });
+  }
+
+  // Transactions
+  Stream<List<Transaction>> watchTransactions(String uid) {
+    return _userCollection(uid, 'transactions').snapshots().map((snapshot) {
+      return snapshot.docs.map((d) {
+        final data = d.data();
+        return Transaction(
+          id: d.id,
+          date: data['date'] ?? '',
+          description: data['description'] ?? '',
+          amount: (data['amount'] ?? 0).toDouble(),
+          type: data['type'] == 'income' ? TransactionType.income : TransactionType.expense,
+          category: data['category'] ?? '',
+          recurrence: data['recurrence'] ?? 'once',
+          currency: data['currency'] ?? 'USD',
+        );
+      }).toList();
+    });
+  }
+
+  Future<void> addTransaction(String uid, Transaction tx) {
+    return _userCollection(uid, 'transactions').doc(tx.id).set({
+      'date': tx.date,
+      'description': tx.description,
+      'amount': tx.amount,
+      'type': tx.type.name,
+      'category': tx.category,
+      'recurrence': tx.recurrence,
+      'currency': tx.currency,
+    });
+  }
+
+  Future<void> deleteTransaction(String uid, String id) {
+    return _userCollection(uid, 'transactions').doc(id).delete();
+  }
+}


### PR DESCRIPTION
## Summary
- convert TypeScript interfaces to Dart models
- expose new enum `TransactionType`
- extend `Budget` with optional transactions list
- expand auth service with email login methods
- add Firestore service for basic CRUD operations

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing dependencies)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2ebf368c8326a255b64091349d8e