### PR TITLE
Add Flutter login and onboarding views

### DIFF
--- a/fintouch_flutter/lib/main.dart
+++ b/fintouch_flutter/lib/main.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'providers/app_state.dart';
+import 'screens/login_screen.dart';
+import 'screens/onboarding_screen.dart';
 import 'theme.dart';
 
 void main() {
@@ -18,8 +20,27 @@ class FintouchApp extends StatelessWidget {
       child: MaterialApp(
         title: 'Fintouch',
         theme: AppTheme.themeData,
-        home: const HomePage(),
+        home: const RootNavigator(),
       ),
+    );
+  }
+}
+
+class RootNavigator extends StatelessWidget {
+  const RootNavigator({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<AppState>(
+      builder: (context, state, _) {
+        if (state.userId.isEmpty) {
+          return const LoginScreen();
+        }
+        if (!state.onboardingComplete) {
+          return const OnboardingScreen();
+        }
+        return const HomePage();
+      },
     );
   }
 }
@@ -34,13 +55,16 @@ class HomePage extends StatelessWidget {
       appBar: AppBar(title: const Text('Fintouch')),
       backgroundColor: AppTheme.backgroundColor,
       body: Center(
-        child: ElevatedButton(
-          onPressed: () => state.setUser('demo'),
-          child: Text(
-            state.userId.isEmpty
-                ? 'Login (mock)'
-                : 'Logged in as ${state.userId}',
-          ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text('Bienvenido, ${state.profile?.name ?? 'Usuario'}'),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => state.signOut(),
+              child: const Text('Cerrar Sesión'),
+            ),
+          ],
         ),
       ),
     );

--- a/fintouch_flutter/lib/providers/app_state.dart
+++ b/fintouch_flutter/lib/providers/app_state.dart
@@ -1,10 +1,32 @@
 import 'package:flutter/foundation.dart';
 
-class AppState extends ChangeNotifier {
-  String userId = '';
+import '../models.dart';
+import '../services/auth_service.dart';
 
-  void setUser(String id) {
-    userId = id;
+class AppState extends ChangeNotifier {
+  final AuthService _authService = AuthService();
+
+  String userId = '';
+  bool onboardingComplete = false;
+  UserProfile? profile;
+
+  Future<void> signIn() async {
+    final cred = await _authService.signInAnonymously();
+    userId = cred.user?.uid ?? '';
+    notifyListeners();
+  }
+
+  Future<void> signOut() async {
+    await _authService.signOut();
+    userId = '';
+    onboardingComplete = false;
+    profile = null;
+    notifyListeners();
+  }
+
+  void completeOnboarding({required String name, required String language, required String currency}) {
+    profile = UserProfile(name: name, language: language, currency: currency);
+    onboardingComplete = true;
     notifyListeners();
   }
 }

--- a/fintouch_flutter/lib/screens/login_screen.dart
+++ b/fintouch_flutter/lib/screens/login_screen.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/app_state.dart';
+import '../theme.dart';
+
+class LoginScreen extends StatelessWidget {
+  const LoginScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final appState = Provider.of<AppState>(context, listen: false);
+
+    return Scaffold(
+      backgroundColor: AppTheme.backgroundColor,
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Bienvenido a Fintouch',
+                style: Theme.of(context).textTheme.headlineMedium,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 32),
+              ElevatedButton(
+                onPressed: () async {
+                  await appState.signIn();
+                },
+                style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                ),
+                child: const Text('Iniciar Sesión'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/fintouch_flutter/lib/screens/onboarding_screen.dart
+++ b/fintouch_flutter/lib/screens/onboarding_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/app_state.dart';
+import '../theme.dart';
+
+class OnboardingScreen extends StatefulWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  State<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends State<OnboardingScreen> {
+  final _formKey = GlobalKey<FormState>();
+  String _name = '';
+  String _language = 'es';
+  String _currency = 'USD';
+
+  @override
+  Widget build(BuildContext context) {
+    final appState = Provider.of<AppState>(context, listen: false);
+
+    return Scaffold(
+      backgroundColor: AppTheme.backgroundColor,
+      appBar: AppBar(title: const Text('Configuración')),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                TextFormField(
+                  decoration: const InputDecoration(labelText: 'Nombre'),
+                  validator: (value) =>
+                      value == null || value.isEmpty ? 'Ingresa tu nombre' : null,
+                  onSaved: (value) => _name = value ?? '',
+                ),
+                const SizedBox(height: 16),
+                DropdownButtonFormField(
+                  value: _language,
+                  decoration: const InputDecoration(labelText: 'Idioma'),
+                  items: const [
+                    DropdownMenuItem(value: 'es', child: Text('Español')),
+                    DropdownMenuItem(value: 'en', child: Text('English')),
+                  ],
+                  onChanged: (value) => setState(() => _language = value as String),
+                ),
+                const SizedBox(height: 16),
+                DropdownButtonFormField(
+                  value: _currency,
+                  decoration: const InputDecoration(labelText: 'Moneda'),
+                  items: const [
+                    DropdownMenuItem(value: 'USD', child: Text('USD (\$)')),
+                    DropdownMenuItem(value: 'EUR', child: Text('EUR (€)')),
+                    DropdownMenuItem(value: 'ARS', child: Text('ARS (\$)')),
+                    DropdownMenuItem(value: 'GBP', child: Text('GBP (£)')),
+                  ],
+                  onChanged: (value) => setState(() => _currency = value as String),
+                ),
+                const SizedBox(height: 24),
+                ElevatedButton(
+                  onPressed: () {
+                    if (_formKey.currentState!.validate()) {
+                      _formKey.currentState!.save();
+                      appState.completeOnboarding(
+                        name: _name,
+                        language: _language,
+                        currency: _currency,
+                      );
+                    }
+                  },
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                  ),
+                  child: const Text('Guardar y Continuar'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create login screen to trigger anonymous sign-in
- create onboarding form requesting user info
- expand `AppState` provider to manage auth and onboarding
- wire new screens into `main.dart`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2ec5f8108326a7e2062e3f428055