### PR TITLE
Apply blueprint palette and fonts

### DIFF
--- a/fintouch_flutter/lib/theme.dart
+++ b/fintouch_flutter/lib/theme.dart
@@ -8,16 +8,23 @@ class AppTheme {
 
   static ThemeData get themeData => ThemeData(
         primaryColor: primaryColor,
+        scaffoldBackgroundColor: backgroundColor,
         colorScheme: ColorScheme.fromSeed(
           seedColor: primaryColor,
           primary: primaryColor,
           secondary: accentColor,
           background: backgroundColor,
         ),
-        textTheme: TextTheme(
+        textTheme: GoogleFonts.interTextTheme().copyWith(
+          displayLarge: GoogleFonts.spaceGrotesk(),
+          displayMedium: GoogleFonts.spaceGrotesk(),
+          displaySmall: GoogleFonts.spaceGrotesk(),
+          headlineLarge: GoogleFonts.spaceGrotesk(),
           headlineMedium: GoogleFonts.spaceGrotesk(),
-          bodyLarge: GoogleFonts.inter(),
-          bodyMedium: GoogleFonts.inter(),
+          headlineSmall: GoogleFonts.spaceGrotesk(),
+          titleLarge: GoogleFonts.spaceGrotesk(),
+          titleMedium: GoogleFonts.spaceGrotesk(),
+          titleSmall: GoogleFonts.spaceGrotesk(),
         ),
       );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,7 +4,7 @@
 
 @layer base {
   :root {
-    --background: 218 93% 95%;
+    --background: 218 93% 95%; /* #E8F0FE */
     --foreground: 222 47% 11%;
 
     --card: 0 0% 100%;
@@ -16,7 +16,7 @@
     --popover: 0 0% 100%;
     --popover-foreground: 222 47% 11%;
 
-    --primary: 217 89% 61%;
+    --primary: 217 89% 61%; /* #4285F4 */
     --primary-foreground: 0 0% 98%;
 
     --secondary: 210 40% 96.1%;
@@ -25,7 +25,7 @@
     --muted: 210 40% 96.1%;
     --muted-foreground: 210 30% 50%;
 
-    --accent: 145 58% 46%;
+    --accent: 136 53% 43%; /* #34A853 */
     --accent-foreground: 0 0% 98%;
 
     --destructive: 0 72% 51%;
@@ -36,7 +36,7 @@
     --ring: 217 89% 61%;
 
     --chart-1: 217 89% 61%;
-    --chart-2: 145 58% 46%;
+    --chart-2: 136 53% 43%;
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 190 75% 50%;
@@ -57,7 +57,7 @@
     --popover: 217 28% 22%; /* #283548 */
     --popover-foreground: 215 45% 93%; /* #E6ECF4 */
 
-    --primary: 216 100% 61%; /* #3A8CFF */
+    --primary: 217 89% 61%; /* #4285F4 */
     --primary-foreground: 0 0% 100%; /* #FFFFFF */
 
     --secondary: 217 33% 17%; /* #1E2A3A */
@@ -66,7 +66,7 @@
     --muted: 214 22% 11%; /* #151B23 */
     --muted-foreground: 215 13% 66%; /* #9AA5B5 */
 
-    --accent: 160 63% 52%; /* #3AD29F */
+    --accent: 136 53% 43%; /* #34A853 */
     --accent-foreground: 161 100% 5%; /* #001B12 */
 
     --destructive: 0 100% 68%; /* #FF5B5B */
@@ -77,7 +77,7 @@
     --ring: 216 100% 61%; /* #3A8CFF */
 
     --chart-1: 216 100% 61%; /* #3A8CFF */
-    --chart-2: 160 63% 52%; /* #3AD29F */
+    --chart-2: 136 53% 43%; /* #34A853 */
     --chart-3: 31 100% 71%; /* #FFB86C */
     --chart-4: 326 100% 74%; /* #FF79C6 */
     --chart-5: 135 94% 65%; /* #50FA7B */


### PR DESCRIPTION
## Summary
- align Flutter theme with blueprint colors and fonts
- update global CSS variables to use primary `#4285F4`, accent `#34A853` and include hex comments for background and primary

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing types)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2ed114f483268afb16b9fedfcdde